### PR TITLE
Disable picking up items when in builder mode

### DIFF
--- a/src/main/java/us/spaceclouds42/zones/mixin/ItemEntityMixin.java
+++ b/src/main/java/us/spaceclouds42/zones/mixin/ItemEntityMixin.java
@@ -17,11 +17,11 @@ public class ItemEntityMixin {
      * @param ci callback info
      */
     @Inject(
-        method = "onPlayerCollision",
-        at = @At(
-            value = "HEAD"
-        ),
-        cancellable = true
+            method = "onPlayerCollision",
+            at = @At(
+                    value = "HEAD"
+            ),
+            cancellable = true
     )
     public void onPlayerCollision(PlayerEntity player, CallbackInfo ci) {
         if(!player.getEntityWorld().isClient()) {

--- a/src/main/java/us/spaceclouds42/zones/mixin/ItemEntityMixin.java
+++ b/src/main/java/us/spaceclouds42/zones/mixin/ItemEntityMixin.java
@@ -10,14 +10,19 @@ import us.spaceclouds42.zones.access.BuilderAccessor;
 
 @Mixin(ItemEntity.class)
 public class ItemEntityMixin {
-
     /**
      * Prevents a player from picking up any items when in builder mode
      *
-     * @param player player which collides with the item stack
+     * @param player the player that collides with the item stack
      * @param ci callback info
      */
-    @Inject(method = "onPlayerCollision", at = @At(value = "HEAD"), cancellable = true)
+    @Inject(
+        method = "onPlayerCollision",
+        at = @At(
+            value = "HEAD"
+        ),
+        cancellable = true
+    )
     public void onPlayerCollision(PlayerEntity player, CallbackInfo ci) {
         if(!player.getEntityWorld().isClient()) {
             if(((BuilderAccessor) player).isInBuilderMode()) {

--- a/src/main/java/us/spaceclouds42/zones/mixin/ItemEntityMixin.java
+++ b/src/main/java/us/spaceclouds42/zones/mixin/ItemEntityMixin.java
@@ -1,0 +1,28 @@
+package us.spaceclouds42.zones.mixin;
+
+import net.minecraft.entity.ItemEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import us.spaceclouds42.zones.access.BuilderAccessor;
+
+@Mixin(ItemEntity.class)
+public class ItemEntityMixin {
+
+    /**
+     * Prevents a player from picking up any items when in builder mode
+     *
+     * @param player player which collides with the item stack
+     * @param ci callback info
+     */
+    @Inject(method = "onPlayerCollision", at = @At(value = "HEAD"), cancellable = true)
+    public void onPlayerCollision(PlayerEntity player, CallbackInfo ci) {
+        if(!player.getEntityWorld().isClient()) {
+            if(((BuilderAccessor) player).isInBuilderMode()) {
+                ci.cancel(); // Cancel interaction and prevent picking up an item stack
+            }
+        }
+    }
+}

--- a/src/main/java/us/spaceclouds42/zones/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/us/spaceclouds42/zones/mixin/ServerPlayerEntityMixin.java
@@ -2,7 +2,6 @@ package us.spaceclouds42.zones.mixin;
 
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;

--- a/src/main/java/us/spaceclouds42/zones/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/us/spaceclouds42/zones/mixin/ServerPlayerEntityMixin.java
@@ -2,6 +2,7 @@ package us.spaceclouds42.zones.mixin;
 
 import net.fabricmc.fabric.api.util.NbtType;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.ItemEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;

--- a/src/main/resources/zones.mixins.json
+++ b/src/main/resources/zones.mixins.json
@@ -5,6 +5,7 @@
   "mixins": [
     "ChunkSectionAccessor",
     "EntityMixin",
+    "ItemEntityMixin",
     "PlayerMoveC2SPacketAccessor",
     "ProjectileEntityMixin",
     "ServerPlayerEntityMixin",


### PR DESCRIPTION
Disables picking up items when in builder mode. Tried the `ServerPlayerEntity` class but that didn't really work :P.