### PR TITLE
Fix desync when swapping inventories

### DIFF
--- a/src/main/java/us/spaceclouds42/zones/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/us/spaceclouds42/zones/mixin/ServerPlayerEntityMixin.java
@@ -59,6 +59,7 @@ abstract class ServerPlayerEntityMixin implements BuilderAccessor {
     public void swapInventories() {
         PlayerInventory tempInventory = new PlayerInventory((PlayerEntity) (Object) this);
         tempInventory.clone(this.secondaryInventory);
+        tempInventory.selectedSlot = this.inventory.selectedSlot;
         this.secondaryInventory.clone(this.inventory);
         this.inventory.clone(tempInventory);
 


### PR DESCRIPTION
The selected slot gets saved when swapping inventories. This can cause a desync, as the server selected slot will be different to the client selected slot and wrong blocks will be placed.